### PR TITLE
Feature/article_index_create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,6 @@ migrate:
 cache:
 	php artisan config:cache
 mysql:
-	mysql -h 127.0.0.1 -P 3306 -u user -ppassword
-app_route:
-	docker compose exec app bash
-	php artisan route:list > route.txt
+	mysql -h 127.0.0.1 -P 3306 -u user -password
 route:
 	php artisan route:list > route.txt

--- a/src/app/Http/Controllers/ArticleController.php
+++ b/src/app/Http/Controllers/ArticleController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Article;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\View\View;
+
+class ArticleController extends Controller
+{
+    public function index(): View
+    {
+        $user = Auth::user(); // 認証済みユーザー情報取得
+        $articles = $user->articles; // 認証済みユーザーの記事取得
+
+        return view('articles.index', [
+            'articles' => $articles,
+            'user' => $user
+        ]);
+    }
+
+    public function create()
+    {
+        return view('articles.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'title' => 'required|max:100',
+            'body' => 'required'
+        ]);
+
+        // リクエストからボディ取得、保存
+        $article = new Article();
+        $article->user_id = Auth::user()->id;
+        $article->title = $request->title;
+        $article->body = $request->body;
+        $article->is_published = $request->is_published;
+        $article->save();
+
+        // 処理後リダイレクト
+        return redirect('/article');
+    }
+}

--- a/src/app/Models/Article.php
+++ b/src/app/Models/Article.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Article extends Model
+{
+    use HasFactory;
+
+    // 各列の登録を許可する(ホワイトリスト)
+    protected $fillable = ['user_id', 'title', 'body', 'html_content', 'is_published', 'created_at'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -45,4 +45,8 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function articles() {
+        return $this->hasMany(Article::class);
+    }
 }

--- a/src/database/factories/ArticleFactory.php
+++ b/src/database/factories/ArticleFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Article;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Article>
+ */
+class ArticleFactory extends Factory
+{
+    protected $model = Article::class;
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => \App\Models\User::factory(),
+            'title' => $this->faker->sentence(),
+            'body' => $this->faker->paragraphs(3, true),
+            'is_published' => $this->faker->boolean(),
+        ];
+    }
+}

--- a/src/database/migrations/2025_02_11_081657_create_articles_table.php
+++ b/src/database/migrations/2025_02_11_081657_create_articles_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id(); // 主キー
+            $table->foreignId('user_id')
+                ->constrained('users') // usersテーブルのidを参照
+                ->cascadeOnDelete();   // ユーザー削除時に関連する記事も削除
+            $table->string('title', 100); // 記事のタイトル（最大100文字）
+            $table->text('body');         // マークダウン形式の本文（ユーザー入力）
+            $table->text('html_content')->nullable(); // HTML変換後の本文（表示用キャッシュ）
+            $table->boolean('is_published')->default(false); // 公開状態（false:下書き, true:公開）
+            $table->timestamps();         // 作成日時と更新日時（created_at, updated_at）
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('articles');
+    }
+};

--- a/src/database/seeders/ArticleSeeder.php
+++ b/src/database/seeders/ArticleSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Article;
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class ArticleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $users = User::all();
+        foreach ($users as $user) {
+            Article::factory()->count(10)->create([
+                'user_id' => $user->id,
+            ]);
+        }
+    }
+}

--- a/src/database/seeders/DatabaseSeeder.php
+++ b/src/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            UserSeeder::class,
+            ArticleSeeder::class,
         ]);
     }
 }

--- a/src/database/seeders/UserSeeder.php
+++ b/src/database/seeders/UserSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\User;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        User::factory()->count(10)->create();
+    }
+}

--- a/src/package.json
+++ b/src/package.json
@@ -3,7 +3,8 @@
     "type": "module",
     "scripts": {
         "build": "vite build",
-        "dev": "vite"
+        "dev": "vite",
+        "watch": "vite build --watch"
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.2",

--- a/src/resources/views/articles/create.blade.php
+++ b/src/resources/views/articles/create.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.parents')
+@section('title', 'Articleのcreate')
+@section('content')
+
+<div class="w-full md:p-6 p-4">
+    <form method="POST" action="{{ route('article.store') }}">
+        @csrf
+        <div class="flex items-center justify-between font-bold">
+            <h2 class="text-3xl">記事作成</h2>
+            <div class="flex items-center gap-3">
+                <label for="is_published">公開状態</label>
+                <select name="is_published" for="is_published" class="rounded-lg">
+                    <option value="0">下書き</option>
+                    <option value="1">公開</option>
+                </select>
+                <button type="submit" class="text-white bg-accent p-2 rounded-lg hover:opacity-70">作成する</button>
+                <a href="{{ route('article.index') }}" class="text-primary rounded-lg hover:opacity-70">一覧ページへ</a>
+            </div>
+        </div>
+        <div class="mt-4 text-2xl font-bold flex items-center w-full">
+            <label for="title" class="mr-4">タイトル：</label>
+            <input id="title" name="title" type="text" class="flex-grow h-12 rounded-lg" placeholder="記事のタイトルを入力してください">
+        </div>
+        <div class="mt-4 flex-col">
+            <label for="body" class="text-2xl font-bold">本文</label>
+            <textarea name="body" id="body" class="mt-2 w-full h-screen rounded-lg" placeholder="記事の本文を入力してください"></textarea>
+        </div>
+    </form>
+</div>
+
+@endsection

--- a/src/resources/views/articles/index.blade.php
+++ b/src/resources/views/articles/index.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.parents')
+@section('title', 'Articleのインデックスページ')
+@section('content')
+
+<div class="w-full md:p-6 p-4">
+    <h2 class="text-4xl font-bold text-center">記事一覧</h2><!-- ページタイトル -->
+    <div class="grid grid-flow-col grid-row2 gap-6 mt-6">
+        <div class="row-span-2 row-end-3 border border-primary text-center rounded-lg p-6">
+            <h3 class="text-2xl font-bold">ユーザー名：{{ $user->name }}</h3><!-- 作成者 -->
+            <p>hogehogehogehogehogehogehogehogehoge<br>hogehogehogehogehoge</p>
+        </div>
+        <div class="row-start-1 row-end-4 flex flex-col flex-grow gap-6">
+            @foreach ($articles as $article)
+                <div class="p-6 justify-center rounded-lg border border-primary">
+                    <h3 class="text-2xl font-bold">{{ $article->title }}</h3><!-- 記事タイトル -->
+                    <p class="p-3 text-main">作成者：{{ $article->user->name }}</p><!-- 作成者 -->
+                    <p class="p-3 text-main">{{ $article->is_published }}</p><!-- 下書き・公開 -->
+                    <p class="p-3 text-main">{{ $article->created_at }}</p><!-- 作成日 -->
+                </div><!-- 記事を取り出す -->
+            @endforeach
+        </div>
+    </div>
+</div>
+
+@endsection

--- a/src/resources/views/components/footer.blade.php
+++ b/src/resources/views/components/footer.blade.php
@@ -1,11 +1,11 @@
-<footer class="bg-[#0078D7] p-4 md:p-6 text-white">
+<footer class="bg-primary p-4 md:p-6 text-white">
     <div class="text-center">
-        <div><a class="text-3xl font-bold text-white hover:text-[#00BFFF]" href="{{ route('top') }}">Tech Draft AI</a></div>
+        <div><a class="text-3xl font-bold text-white hover:text-accent" href="{{ route('top') }}">Tech Draft AI</a></div>
         <nav class="font-bold mt-4">
             <ul class="flex gap-6 justify-center">
-                <li><a href="" class="hover:text-[#00BFFF] transition duration-200">トップ</a></li>
-                <li><a href="" class="hover:text-[#00BFFF] transition duration-200">プライバシーポリシー</a></li>
-                <li><a href="" class="hover:text-[#00BFFF] transition duration-200">利用規約</a></li>
+                <li><a href="" class="hover:text-accent transition duration-200">トップ</a></li>
+                <li><a href="" class="hover:text-accent transition duration-200">プライバシーポリシー</a></li>
+                <li><a href="" class="hover:text-accent transition duration-200">利用規約</a></li>
             </ul>
         </nav>
         <p class="text-sm mt-4 md:mt-6">Copyright © Tech Draft AI All Rights Reserved.</p>

--- a/src/resources/views/components/header.blade.php
+++ b/src/resources/views/components/header.blade.php
@@ -1,13 +1,13 @@
-<header class="fixed top-0 p-4 md:p-6 text-[#333333] w-full z-10">
-    <div class="flex justify-between items-center bg-[#0078D7] shadow-md p-4 md:p-6 rounded-lg font-bold">
-        <h1><a class="text-3xl text-white hover:text-[#00BFFF]" href="{{ route('top') }}">Tech Draft AI</a></h1>
+<header class="sticky top-0 p-4 md:p-6 text-white w-full z-10">
+    <div class="flex justify-between items-center bg-primary shadow-md p-4 md:p-6 rounded-lg font-bold">
+        <h1><a class="text-4xl text-white hover:text-accent" href="{{ route('top') }}">Tech Draft AI</a></h1>
         <nav>
             <ul class="flex items-center gap-6">
-                <li><a href="{{ route('top') }}" class="text-white hover:text-[#00BFFF] transition duration-200">トップ</a></li>
-                <li><a href="{{ route('register') }}" class="text-white hover:text-[#00BFFF] transition duration-200">新規登録</a></li>
-                <li><a href="{{ route('login') }}" class="text-white hover:text-[#00BFFF] transition duration-200">ログイン</a></li>
+                <li><a href="{{ route('top') }}" class="text-white hover:text-accent transition duration-200">トップ</a></li>
+                <li><a href="{{ route('register') }}" class="text-white hover:text-accent transition duration-200">新規登録</a></li>
+                <li><a href="{{ route('login') }}" class="text-white hover:text-accent transition duration-200">ログイン</a></li>
             </ul>
         </nav>
-        <button class="bg-[#00BFFF] text-white hover:bg-[#fff] p-2 rounded-md transition duration-200">記事を書く</button>
+        <a href="{{ route('article.create') }}" class="bg-accent text-white hover:bg-white hover:text-accent p-2 rounded-md transition duration-200">記事を書く</a>
     </div>
 </header>

--- a/src/resources/views/layouts/parents.blade.php
+++ b/src/resources/views/layouts/parents.blade.php
@@ -11,7 +11,7 @@
 
 <body>
     @include('components.header')
-    <div class="text-[#333333]">
+    <div class="text-main">
         @yield('content')
     </div>
     @include('components.footer')

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\ArticleController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -15,6 +16,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    Route::resource('/article', ArticleController::class);
 });
 
 require __DIR__.'/auth.php';

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -15,6 +15,13 @@ export default {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
         },
+        colors: {
+            'main': '#333333', // 文章 黒
+            'white': '#FFFFFF', // 文章 白
+            'primary': '#0078D7', // メイン背景 青
+            'sub': '#E6E6E6', // サブ背景 シルバー
+            'accent': '#00BFFF', // アクセント 水色
+        },
     },
 
     plugins: [forms],


### PR DESCRIPTION
# 概要
記事一覧・作成機能を実装。

# やったこと
- articleのマイグレーションファイルとテーブル作成
- articleのモデル作成
  - userとarticleの紐付け
- シーディングでダミーデータ投入
- articleコントローラーの作成
  - indexメソッド、createメソッド、storeメソッド設定
- ルーティングの設定
  - 認証後に表示
- ビューファイルの作成
  - index.blade.php
  - create.blade.php
- Makefileのmysqlコマンド修正
- package.jsonにwatchコマンド追加
- tailwind.config.jsにcolorテーマを設定
  - header.blade.phpのcolorを変更
  - footer.blade.phpのcolorを変更
  - parent.blade.phpのcolorを変更

## なぜやるのか
- articleのデータを格納するためにマイグレーションファイルとテーブルを作成
- articleのモデルを作成することで、テーブルとのやり取りを可能にする
  - userとarticleの紐付けを行うことで、articleからuserへのアクセスを可能とする
- articleのコントローラーを作成することで、indexアクションで認証済みユーザーの記事の取得を行う。そして、storeメソッドで作成された記事の保存を可能にする
- ルーティングの設定を行うことで、一連のCRUDにおける経路を確立し、アクセスできるようにする
- index.blade.phpで認証済みでログイン中のユーザーが作成した記事を表示できるようにする
- create.blade.phpで記事作成をできるようにする
- Makefileでmysqlコマンドが適用されなかったため修正
- package.jsonにwatchコマンドを追加することで、変更を常に監視されるようにしたため開発効率を上げられたため
- tailwind.config.jsにcolorテーマを設定することで、使用すべきカラーを明確にし、クラスへの記述もわかりやすくした
- header.blade.php、footer.blade.php、parent.blade.phpにカラーコードを設定していたが、colorテーマを適用することに統一した

## 変更内容
- articleのマイグレーションファイルには、id「主キー」、user_id「外部キー」、title「タイトル」、body「本文」、html_content「マークダウン」、is_published「公開状態（false:下書き, true:公開）」、timestamps「作成日時と更新日時（created_at, updated_at）」記述
- articleモデル多に対して、userモデルを1に設定
- articleコントローラーのindexアクションを認証済みユーザーの記事取得、storeメソッドで作成された各フォーム情報を保存
- ルーティングで認証済みのところに一連のCRUDに関するリソースを作成
- index.blade.phpでarticleコントローラーから取得したユーザー名、そのユーザーの記事情報を取得し、一覧表示
- create.blade.phpで記事作成できるビューを作成。articleコントローラーのstoreメソッドへ
- Makefileのmysqlコマンド修正
- package.jsonにwatchコマンド追加
- tailwind.config.jsにcolorテーマを追加し、main、white、primary、sub、accentを設定
- header.blade.php、footer.blade.php、parent.blade.phpのカラーコードを排除し、colorテーマを適用

# 動作確認
- macbook環境
- 一覧表示から作成まで
[![Image from Gyazo](https://i.gyazo.com/c44022885e0d97314b52d0108ab0ecb4.gif)](https://gyazo.com/c44022885e0d97314b52d0108ab0ecb4)

# その他
- 見た目などのcssはこれから先、調整します。
- 一連のことをまとめた記事
https://qiita.com/rei-dev99/items/717a0b668ac2acec9edb
- Laravelドキュメント「認証」
https://laravel.com/docs/11.x/authentication
- Readoubleマニュアル「認証」
https://readouble.com/laravel/11.x/ja/authentication.html

- 参考記事
https://qiita.com/ucan-lab/items/a7441bff64ff1f173c10