### PR TITLE
Feature article detail

### DIFF
--- a/src/app/Http/Controllers/ArticleController.php
+++ b/src/app/Http/Controllers/ArticleController.php
@@ -46,4 +46,12 @@ class ArticleController extends Controller
         // 処理後リダイレクト
         return redirect('/article');
     }
+
+    public function show($id) {
+        $article = Article::find($id);
+
+        return view('articles.show', [
+            'article' => $article
+        ]);
+    }
 }

--- a/src/resources/views/articles/index.blade.php
+++ b/src/resources/views/articles/index.blade.php
@@ -1,22 +1,50 @@
 @extends('layouts.parents')
-@section('title', 'Articleのインデックスページ')
+@section('title', '記事一覧')
 @section('content')
 
-<div class="w-full md:p-6 p-4">
-    <h2 class="text-4xl font-bold text-center">記事一覧</h2><!-- ページタイトル -->
-    <div class="grid grid-flow-col grid-row2 gap-6 mt-6">
-        <div class="row-span-2 row-end-3 border border-primary text-center rounded-lg p-6">
-            <h3 class="text-2xl font-bold">ユーザー名：{{ $user->name }}</h3><!-- 作成者 -->
-            <p>hogehogehogehogehogehogehogehogehoge<br>hogehogehogehogehoge</p>
+<div class="w-full max-w-6xl mx-auto py-8 px-4">
+    <h1 class="text-4xl font-bold text-main mb-8 text-center">記事一覧</h1>
+
+    <div class="flex flex-col md:flex-row gap-8">
+        <!-- ユーザープロフィール -->
+        <div class="md:w-1/4">
+            <div class="bg-white border border-sub rounded-lg p-6 sticky top-4">
+                <img src="https://www.gravatar.com/avatar/{{ md5($user->email) }}?s=200&d=mp" alt="{{ $user->name }}" class="w-32 h-32 rounded-full mx-auto mb-4">
+                <h2 class="text-2xl font-bold text-main text-center mb-2">{{ $user->name }}</h2>
+                <p class="text-main text-center mb-4">ユーザーの自己紹介文がここに入ります。</p>
+                <div class="flex justify-center">
+                    <a href="{{ route('article.create') }}" class="bg-primary text-white px-4 py-2 rounded-lg hover:bg-accent transition duration-300 ease-in-out">新規記事作成</a>
+                </div>
+            </div>
         </div>
-        <div class="row-start-1 row-end-4 flex flex-col flex-grow gap-6">
+
+        <!-- 記事リスト -->
+        <div class="md:w-3/4">
             @foreach ($articles as $article)
-                <div class="p-6 justify-center rounded-lg border border-primary">
-                    <h3 class="text-2xl font-bold">{{ $article->title }}</h3><!-- 記事タイトル -->
-                    <p class="p-3 text-main">作成者：{{ $article->user->name }}</p><!-- 作成者 -->
-                    <p class="p-3 text-main">{{ $article->is_published }}</p><!-- 下書き・公開 -->
-                    <p class="p-3 text-main">{{ $article->created_at }}</p><!-- 作成日 -->
-                </div><!-- 記事を取り出す -->
+                <div class="bg-white border border-sub rounded-lg p-6 mb-6 hover:shadow-lg transition duration-300 ease-in-out">
+                    <h3 class="text-2xl font-bold mb-2">
+                        <a href="{{ route('article.show', ['article' => $article->id]) }}" class="text-primary hover:text-accent">
+                            {{ $article->title }}
+                        </a>
+                    </h3>
+                    <div class="flex items-center text-sm text-accent mb-4">
+                        <span class="mr-4">投稿: {{ $article->created_at->format('Y年m月d日') }}</span>
+                        <span class="mr-4">更新: {{ $article->updated_at->format('Y年m月d日') }}</span>
+                        <span class="{{ $article->is_published ? 'text-accent' : 'text-sub' }}">
+                            {{ $article->is_published ? '公開' : '下書き' }}
+                        </span>
+                    </div>
+                    <p class="text-main mb-4">{{ Str::limit($article->body, 150) }}</p>
+                    <div class="flex justify-between items-center">
+                        <a href="{{ route('article.show', ['article' => $article->id]) }}" class="text-primary hover:text-accent">
+                            続きを読む
+                        </a>
+                        <div class="flex items-center">
+                            <img src="https://www.gravatar.com/avatar/{{ md5($article->user->email) }}?s=30&d=mp" alt="{{ $article->user->name }}" class="w-6 h-6 rounded-full mr-2">
+                            <span class="text-main">{{ $article->user->name }}</span>
+                        </div>
+                    </div>
+                </div>
             @endforeach
         </div>
     </div>

--- a/src/resources/views/articles/show.blade.php
+++ b/src/resources/views/articles/show.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.parents')
+@section('title', $article->title)
+@section('content')
+<div class="w-full max-w-4xl mx-auto py-8 px-4">
+    <div class="mb-8">
+        <h1 class="text-4xl font-bold text-main mb-4">{{ $article->title }}</h1>
+        <div class="flex items-center text-sm text-accent">
+            <img src="https://www.gravatar.com/avatar/{{ md5($article->user->email) }}?s=50&d=mp" alt="{{ $article->user->name }}" class="w-10 h-10 rounded-full mr-3 border border-accent">
+            <span class="mr-4">{{ $article->user->name }}</span>
+            <span class="mr-4">投稿: {{ $article->created_at->format('Y年m月d日') }}</span>
+            <span>更新: {{ $article->updated_at->format('Y年m月d日') }}</span>
+        </div>
+    </div>
+
+    <article class="bg-white border border-sub rounded-lg shadow-lg p-8 mb-8">
+        <div class="prose max-w-none text-main">
+            {{ $article->body }}
+        </div>
+    </article>
+
+    <div class="flex justify-between items-center">
+        <a href="{{ route('article.index') }}" class="text-primary hover:text-accent transition duration-300 ease-in-out">
+            <i class="fas fa-arrow-left mr-2"></i>記事一覧に戻る
+        </a>
+        <div>
+            <a href="#" class="bg-primary text-white px-4 py-2 rounded-lg hover:bg-accent transition duration-300 ease-in-out mr-2">編集</a>
+            <button type="submit" class="bg-accent text-white px-4 py-2 rounded-lg hover:bg-primary transition duration-300 ease-in-out">削除</button>
+        </div>
+    </div>
+</div>
+
+@endsection


### PR DESCRIPTION
# 概要
記事の詳細ページ実装

# やったこと
記事の詳細ページ実装のために、ページ遷移やページを作成した。

## なぜやるのか
- showアクションを定義することで記事の詳細を見れるようにするため
- indexページでshowページに遷移できるようにすることで記事の詳細を見れるようにするため
- showページを実装することで記事の詳細を見れるようにした

## 変更内容
- Articleコントローラーにshowアクションを定義
- articleのindexのCSS修正と詳細ページへのroute設定
- articleのshowページ作成

# 動作確認
[![Image from Gyazo](https://i.gyazo.com/aba283905b31a8463fcddbc3bec82a46.gif)](https://gyazo.com/aba283905b31a8463fcddbc3bec82a46)
