### PR TITLE
[feat]記事の編集と削除機能実装

### DIFF
--- a/src/app/Http/Controllers/ArticleController.php
+++ b/src/app/Http/Controllers/ArticleController.php
@@ -47,11 +47,43 @@ class ArticleController extends Controller
         return redirect('/article');
     }
 
-    public function show($id) {
+    public function show($id)
+    {
         $article = Article::find($id);
 
         return view('articles.show', [
             'article' => $article
         ]);
+    }
+
+    public function edit($id)
+    {
+        $article = Auth::user()->articles->find($id);
+
+        return view('articles.edit', [
+            'article' => $article
+        ]);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $request->validate([
+            'title' => 'required|max:100',
+            'body' => 'required',
+            'is_published' => 'required|boolean'
+        ]);
+
+        $article = Auth::user()->articles->find($id);
+        $article->update($request->all());
+
+        return redirect()->route('article.show', $article)->with('success', '記事が更新されました。');
+    }
+
+    public function destroy($id)
+    {
+        $article = Auth::user()->articles->find($id);
+        $article->delete();
+
+        return redirect('/article')->with('success', '記事が削除されました。');
     }
 }

--- a/src/resources/views/articles/edit.blade.php
+++ b/src/resources/views/articles/edit.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.parents')
+@section('title', 'Articleのcreate')
+@section('content')
+
+<div class="w-full md:p-6 p-4">
+    <form method="POST" action="{{ route('article.update', $article->id) }}" enctype="multipart/form-data">
+        @csrf
+        @method('PUT')
+        <input type="hidden" name="user_id" value="{{ Auth::user()->id }}">
+        <div class="flex items-center justify-between font-bold">
+            <h2 class="text-3xl">記事作成</h2>
+            <div class="flex items-center gap-3">
+                <label for="is_published">公開状態</label>
+                <select name="is_published" for="is_published" class="rounded-lg">
+                    <option value="0" @if($article->is_published == 0) selected @endif></option>下書き</option>
+                    <option value="1" @if($article->is_published == 1) selected @endif>公開</option>
+                </select>
+                <button type="submit" class="text-white bg-accent p-2 rounded-lg hover:opacity-70">更新する</button>
+                <a href="{{ route('article.index') }}" class="text-primary rounded-lg hover:opacity-70">一覧ページへ</a>
+            </div>
+        </div>
+        <div class="mt-4 text-2xl font-bold flex items-center w-full">
+            <label for="title" class="mr-4">タイトル：</label>
+            <input id="title" name="title" value="{{ $article->title }}" type="text" class="flex-grow h-12 rounded-lg" placeholder="記事のタイトルを入力してください">
+        </div>
+        <div class="mt-4 flex-col">
+            <label for="body" class="text-2xl font-bold">本文</label>
+            <textarea name="body" id="body" class="mt-2 w-full h-screen rounded-lg" placeholder="記事の本文を入力してください">{{ $article->body }}</textarea>
+        </div>
+    </form>
+</div>
+
+@endsection

--- a/src/resources/views/articles/index.blade.php
+++ b/src/resources/views/articles/index.blade.php
@@ -8,7 +8,7 @@
     <div class="flex flex-col md:flex-row gap-8">
         <!-- ユーザープロフィール -->
         <div class="md:w-1/4">
-            <div class="bg-white border border-sub rounded-lg p-6 sticky top-4">
+            <div class="bg-white border border-sub rounded-lg p-6 sticky top-[136px]">
                 <img src="https://www.gravatar.com/avatar/{{ md5($user->email) }}?s=200&d=mp" alt="{{ $user->name }}" class="w-32 h-32 rounded-full mx-auto mb-4">
                 <h2 class="text-2xl font-bold text-main text-center mb-2">{{ $user->name }}</h2>
                 <p class="text-main text-center mb-4">ユーザーの自己紹介文がここに入ります。</p>
@@ -21,30 +21,40 @@
         <!-- 記事リスト -->
         <div class="md:w-3/4">
             @foreach ($articles as $article)
-                <div class="bg-white border border-sub rounded-lg p-6 mb-6 hover:shadow-lg transition duration-300 ease-in-out">
-                    <h3 class="text-2xl font-bold mb-2">
-                        <a href="{{ route('article.show', ['article' => $article->id]) }}" class="text-primary hover:text-accent">
-                            {{ $article->title }}
-                        </a>
-                    </h3>
-                    <div class="flex items-center text-sm text-accent mb-4">
-                        <span class="mr-4">投稿: {{ $article->created_at->format('Y年m月d日') }}</span>
-                        <span class="mr-4">更新: {{ $article->updated_at->format('Y年m月d日') }}</span>
-                        <span class="{{ $article->is_published ? 'text-accent' : 'text-sub' }}">
-                            {{ $article->is_published ? '公開' : '下書き' }}
-                        </span>
-                    </div>
-                    <p class="text-main mb-4">{{ Str::limit($article->body, 150) }}</p>
-                    <div class="flex justify-between items-center">
-                        <a href="{{ route('article.show', ['article' => $article->id]) }}" class="text-primary hover:text-accent">
-                            続きを読む
-                        </a>
-                        <div class="flex items-center">
-                            <img src="https://www.gravatar.com/avatar/{{ md5($article->user->email) }}?s=30&d=mp" alt="{{ $article->user->name }}" class="w-6 h-6 rounded-full mr-2">
-                            <span class="text-main">{{ $article->user->name }}</span>
-                        </div>
+            <div class="bg-white border border-sub rounded-lg p-6 mb-6 hover:shadow-lg transition duration-300 ease-in-out">
+                <h3 class="text-2xl font-bold mb-2">
+                    <a href="{{ route('article.show', ['article' => $article->id]) }}" class="text-primary hover:text-accent">
+                        {{ $article->title }}
+                    </a>
+                </h3>
+                <div class="flex items-center text-sm text-accent mb-4">
+                    <span class="mr-4">投稿: {{ $article->created_at->format('Y年m月d日') }}</span>
+                    <span class="mr-4">更新: {{ $article->updated_at->format('Y年m月d日') }}</span>
+                    <span class="{{ $article->is_published ? 'text-accent' : 'text-sub' }}">
+                        {{ $article->is_published ? '公開' : '下書き' }}
+                    </span>
+                </div>
+                <p class="text-main mb-4">{{ Str::limit($article->body, 150) }}</p>
+                <div class="flex justify-between items-center">
+                    <a href="{{ route('article.show', ['article' => $article->id]) }}" class="text-primary hover:text-accent">
+                        続きを読む
+                    </a>
+                    <div class="flex items-center">
+                        <img src="https://www.gravatar.com/avatar/{{ md5($article->user->email) }}?s=30&d=mp" alt="{{ $article->user->name }}" class="w-6 h-6 rounded-full mr-2">
+                        <span class="text-main">{{ $article->user->name }}</span>
                     </div>
                 </div>
+                @if (Auth::id() === $article->user_id)
+                <div class="flex gap-2 mt-4">
+                    <a href="{{ route('article.edit', $article->id) }}" class="bg-primary text-white px-4 py-2 rounded-lg hover:bg-accent transition duration-300 ease-in-out mr-2">編集</a>
+                    <form action="{{ route('article.destroy', $article->id) }}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="bg-accent text-white px-4 py-2 rounded-lg hover:bg-primary transition duration-300 ease-in-out" onclick="if(!confirm('本当に削除しますか？')){return false};">削除</button>
+                    </form>
+                </div>
+                @endif
+            </div>
             @endforeach
         </div>
     </div>

--- a/src/resources/views/articles/show.blade.php
+++ b/src/resources/views/articles/show.blade.php
@@ -22,10 +22,18 @@
         <a href="{{ route('article.index') }}" class="text-primary hover:text-accent transition duration-300 ease-in-out">
             <i class="fas fa-arrow-left mr-2"></i>記事一覧に戻る
         </a>
-        <div>
-            <a href="#" class="bg-primary text-white px-4 py-2 rounded-lg hover:bg-accent transition duration-300 ease-in-out mr-2">編集</a>
-            <button type="submit" class="bg-accent text-white px-4 py-2 rounded-lg hover:bg-primary transition duration-300 ease-in-out">削除</button>
+
+        <div class="flex gap-2">
+            @if ($article->user == Auth::user())
+            <a href="{{ route('article.edit', $article->id) }}" class="bg-primary text-white px-4 py-2 rounded-lg hover:bg-accent transition duration-300 ease-in-out mr-2">編集</a>
+            <form action="{{ route('article.destroy', $article->id) }}" method="POST">
+                @csrf
+                @method('DELETE')
+                <button type="submit" class="bg-accent text-white px-4 py-2 rounded-lg hover:bg-primary transition duration-300 ease-in-out" onclick="if(!confirm('本当に削除しますか？')){return false};">削除</button>
+            </form>
+            @endif
         </div>
+
     </div>
 </div>
 


### PR DESCRIPTION
# 概要
記事の編集と削除機能の実装を行いました。

# やったこと
- Articleコントローラーにedit、update、destroyアクション追加
- indexページ、showページから編集と削除ができるようにした。

## なぜやるのか
- コントローラーにアクションを追加することでモデル間で編集、更新、削除をORMでできるようにするため。

## 変更内容
- ■動線を整える
  - src/resources/views/articles/index.blade.phpを編集する
  - src/resources/views/articles/show.blade.phpを編集する
- ■掲示板編集・削除
  - src/app/Http/Controllers/ArticleController.phpを編集する
  - src/resources/views/articles/edit.blade.phpを生成・編集する

# 動作確認
[![Image from Gyazo](https://i.gyazo.com/28dcfca9b2fb668a969deeba8840594b.gif)](https://gyazo.com/28dcfca9b2fb668a969deeba8840594b)

# その他
- 編集や削除後のページ遷移はこれから考えます。